### PR TITLE
Removed ellipses argument which was causing error to be thrown

### DIFF
--- a/server.R
+++ b/server.R
@@ -18,7 +18,6 @@ function(input, output) {
               ylab = input$scatterD3_y,
               col_var = col_var,
               col_lab = input$scatterD3_col,
-              ellipses = input$scatterD3_ellipses,
               symbol_var = symbol_var,
               symbol_lab = input$scatterD3_symbol,
               size_var = size_var,


### PR DESCRIPTION
I removed the `ellipses = input$scatterD3_ellipses` argument from the `server.R` file.  I was getting this error in my Shiny app:

<img width="958" alt="screen shot 2016-02-11 at 9 42 38 pm" src="https://cloud.githubusercontent.com/assets/1373882/12999842/6775731c-d108-11e5-9d88-36d7d287b151.png">

P.S. - very cool -- the transitions from D3 were sorely missing in R.
